### PR TITLE
Change tempalte to use attribute instead of hard code

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -72,7 +72,8 @@ template '/etc/systemd/system/opennms-pris.service' do
   group 'root'
   mode 00755
   variables(
-    app_home: app_home
+    app_home: app_home,
+    java_home: node['pris']['java_home']
   )
   notifies :run, 'execute[systemctl-daemon-reload]', :immediately
   notifies :restart, 'service[opennms-pris]'

--- a/templates/default/opennms-pris.service.erb
+++ b/templates/default/opennms-pris.service.erb
@@ -6,6 +6,6 @@ Description=OpenNMS Provisioning Integration Server
 
 [Service]
 WorkingDirectory=<%= @app_home %>
-ExecStart=/usr/bin/java -cp <%= @app_home %>/lib/*:<%= @app_home %>/opennms-pris.jar org.opennms.pris.Starter
+ExecStart=<%= @java_home %>/bin/java -cp <%= @app_home %>/lib/*:<%= @app_home %>/opennms-pris.jar org.opennms.pris.Starter
 ExecStop=/bin/kill -TERM $MAINPID
 User=<%= node['pris']['user'] %>


### PR DESCRIPTION
I tested both centos 6 and centos 7. Opennms-pris started in both environments as expected